### PR TITLE
Set cairocffi dependency to version 0.9.0

### DIFF
--- a/recipes/_web_packages.rb
+++ b/recipes/_web_packages.rb
@@ -43,7 +43,10 @@ python_pip 'uwsgi' do
   options '--isolated'
 end
 
-python_pip 'cairocffi'
+# latest version compatible with Python 2.7
+python_pip 'cairocffi' do
+  version '0.9.0'
+end
 
 python_pip 'graphite_web' do
   package_name lazy {


### PR DESCRIPTION
- This to avoid pip install error when using Python 2.7